### PR TITLE
Always require the latest versions of the Grunt dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "url": "https://github.com/multiple-states/bread-butter.git"
   },
   "devDependencies": {
-    "grunt": "^0.4.4",
-    "grunt-autoprefixer": "^0.7.6",
-    "grunt-bower-concat": "^0.3.0",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-cssmin": "^0.9.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-less": "^0.11.0",
-    "grunt-contrib-uglify": "^0.4.1",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-newer": "^1.1.1",
-    "grunt-pixrem": "^0.1.2",
-    "load-grunt-config": "^0.16.0"
+    "grunt": "*",
+    "grunt-autoprefixer": "*",
+    "grunt-bower-concat": "*",
+    "grunt-contrib-clean": "*",
+    "grunt-contrib-copy": "*",
+    "grunt-contrib-cssmin": "*",
+    "grunt-contrib-jshint": "*",
+    "grunt-contrib-less": "*",
+    "grunt-contrib-uglify": "*",
+    "grunt-contrib-watch": "*",
+    "grunt-newer": "*",
+    "grunt-pixrem": "*",
+    "load-grunt-config": "*"
   }
 }


### PR DESCRIPTION
This is done by using "*" instead of a version number in package.json.

SRC: http://stackoverflow.com/questions/25109172/update-grunt-dev-dependencies